### PR TITLE
dashboard: Add a fix to copying on multiple lines

### DIFF
--- a/packages/dashboard/src/Archive/index.js
+++ b/packages/dashboard/src/Archive/index.js
@@ -46,12 +46,7 @@ export default function Archive() {
 
   const onCopy = (event) => {
     const selection = document.getSelection();
-    let re;
-    if (window.chrome) {
-      re = /(.{2,32}#\d{4})\n(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/gm
-    } else {
-      re = /(.{2,32}#\d{4})\r\n(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/gm
-    }
+    const re = /(.{2,32}#\d{4})\s{1,2}(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/gm
     const output = selection.toString().replaceAll(re, "$1 $2")
 
     event.clipboardData.setData('text/plain', output);

--- a/packages/dashboard/src/Archive/index.js
+++ b/packages/dashboard/src/Archive/index.js
@@ -46,7 +46,7 @@ export default function Archive() {
 
   const onCopy = (event) => {
     const selection = document.getSelection();
-    const re = new RegExp("(.{2,32}#\\d{4})\\s(\\d{4}(?:-\\d{2}){2}\\s(?:\\d{2}:){2}\\d{2})", "g")
+    const re = /(.{2,32}#\d{4})\s(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/g
     const output = selection.toString().replaceAll(re, "$1 $2")
 
     event.clipboardData.setData('text/plain', output);

--- a/packages/dashboard/src/Archive/index.js
+++ b/packages/dashboard/src/Archive/index.js
@@ -44,10 +44,19 @@ export default function Archive() {
   const messages = data.messages;
   messages.sort((a, b) => (a.id > b.id ? 1 : -1));
 
+  const onCopy = (event) => {
+    const selection = document.getSelection();
+    const re = new RegExp("(#\\d{4})\\n(\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2})", "g")
+    const output = selection.toString().replaceAll(re, "$1 $2")
+
+    event.clipboardData.setData('text/plain', output);
+    event.preventDefault();
+  }
+
   return (
     <>
       <Header id={id} />
-      <div className="messages">
+      <div className="messages" onCopy={onCopy}>
         {messages.map((message) => (
           <Message data={message} key={message.id} />
         ))}

--- a/packages/dashboard/src/Archive/index.js
+++ b/packages/dashboard/src/Archive/index.js
@@ -46,7 +46,7 @@ export default function Archive() {
 
   const onCopy = (event) => {
     const selection = document.getSelection();
-    const re = new RegExp("(#\\d{4})\\n(\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2})", "g")
+    const re = new RegExp("(.{2,32}#\\d{4})\\s(\\d{4}(?:-\\d{2}){2}\\s(?:\\d{2}:){2}\\d{2})", "g")
     const output = selection.toString().replaceAll(re, "$1 $2")
 
     event.clipboardData.setData('text/plain', output);

--- a/packages/dashboard/src/Archive/index.js
+++ b/packages/dashboard/src/Archive/index.js
@@ -46,7 +46,12 @@ export default function Archive() {
 
   const onCopy = (event) => {
     const selection = document.getSelection();
-    const re = /(.{2,32}#\d{4})\s(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/g
+    let re;
+    if (window.chrome) {
+      re = /(.{2,32}#\d{4})\n(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/gm
+    } else {
+      re = /(.{2,32}#\d{4})\r\n(\d{4}(?:-\d{2}){2}\s(?:\d{2}:){2}\d{2})/gm
+    }
     const output = selection.toString().replaceAll(re, "$1 $2")
 
     event.clipboardData.setData('text/plain', output);


### PR DESCRIPTION
Adds a fix where when you copied from the Archive, you had the date & time on a new line when compared to the name & disc.
This is caused by the HTML tag formatting and to fix that would require injecting the date into the author so it is contained within the same `span` tag, which whilst it is a fix, isn't great and goes against making an author tag.

Instead, this listens to the [`copy`](https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event) event and with a bit of regex, finds the troublesome string and replaces the new line with a space.

This could be shortened to only checking the `#0000\n0000` i.e. the disc + year but that raises the chances of false flags within the text, instead, I went with the somewhat overkill, but near enough guaranteed solution which is matching the disc with the date *and* the timestamp. You could also include the newline after the timestamp for extra checking.